### PR TITLE
Pam's Harvestcraft support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,11 @@ build
 # other
 eclipse
 run
+.DS_Store
 
 # Files from Forge MDK
 forge*changelog.txt
 
 src/generated/resources/.cache/*
 libs/*
+logs/*

--- a/src/main/java/com/rexbas/teletubbies/block/entity/CustardMachineBlockEntity.java
+++ b/src/main/java/com/rexbas/teletubbies/block/entity/CustardMachineBlockEntity.java
@@ -9,6 +9,7 @@ import com.rexbas.teletubbies.init.TeletubbiesItems;
 import com.rexbas.teletubbies.init.TeletubbiesSounds;
 import com.rexbas.teletubbies.inventory.container.CustardMachineContainer;
 import com.rexbas.teletubbies.inventory.container.handler.CustardMachineItemHandler;
+import com.rexbas.teletubbies.inventory.container.slot.SpecificItemSlot;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -38,6 +39,7 @@ public class CustardMachineBlockEntity extends BlockEntity implements MenuProvid
 	private CustardMachineItemHandler outputHandler = new CustardMachineItemHandler(5);
 	private int processTime; // Counting down
 	private boolean isProcessing;
+	private boolean isHoldingBucket;
 	
 	public CustardMachineBlockEntity(BlockPos pos, BlockState state) {
 		super(TeletubbiesBlocks.CUSTARD_MACHINE_BLOCK_ENTITY.get(), pos, state);
@@ -63,7 +65,8 @@ public class CustardMachineBlockEntity extends BlockEntity implements MenuProvid
 							break;
 						}	
 					}
-					outputHandler.insertItem(4, new ItemStack(Items.BUCKET), false);
+					if (isHoldingBucket)
+						outputHandler.insertItem(4, new ItemStack(Items.BUCKET), false);
 					isProcessing = false;
 					setLightState();
 				}
@@ -72,7 +75,9 @@ public class CustardMachineBlockEntity extends BlockEntity implements MenuProvid
 			if (canMakeCustard() && !isProcessing) {
 				
 				for (int i = 0; i < 4; i++) {
-					if (inputHandler.getStackInSlot(i).getItem().equals(Items.MILK_BUCKET)) {
+					ItemStack inputItem = inputHandler.getStackInSlot(i);
+					if (inputItem.is(SpecificItemSlot.MILK)) {
+						isHoldingBucket = inputItem.is(Items.MILK_BUCKET);
 						inputHandler.extractItem(i, 1, false);
 						break;
 					}	
@@ -115,10 +120,10 @@ public class CustardMachineBlockEntity extends BlockEntity implements MenuProvid
 	// returns true if the required items are available and the output slots are not filled, also consumes the imput items
 	public boolean canMakeCustard() {
 		for (int i = 0; i < 4; i++) {
-			if (inputHandler.getStackInSlot(i).getItem().equals(Items.MILK_BUCKET)) {
-				if (inputHandler.getStackInSlot(4).getItem().equals(Items.SUGAR)
-						&& inputHandler.getStackInSlot(5).getItem().equals(Items.EGG)
-						&& inputHandler.getStackInSlot(6).getItem().equals(TeletubbiesItems.BOWL.get())) {
+			if (inputHandler.getStackInSlot(i).is(SpecificItemSlot.MILK)) {
+				if (inputHandler.getStackInSlot(4).is(SpecificItemSlot.SUGAR)
+						&& inputHandler.getStackInSlot(5).is(SpecificItemSlot.EGG)
+						&& inputHandler.getStackInSlot(6).is(SpecificItemSlot.BOWL)) {
 
 					// All items available, check output
 					if (outputHandler.getStackInSlot(4).getCount() < outputHandler.getStackInSlot(4).getMaxStackSize()) {

--- a/src/main/java/com/rexbas/teletubbies/block/entity/ToastMachineBlockEntity.java
+++ b/src/main/java/com/rexbas/teletubbies/block/entity/ToastMachineBlockEntity.java
@@ -9,6 +9,7 @@ import com.rexbas.teletubbies.init.TeletubbiesItems;
 import com.rexbas.teletubbies.init.TeletubbiesSounds;
 import com.rexbas.teletubbies.inventory.container.ToastMachineContainer;
 import com.rexbas.teletubbies.inventory.container.handler.ToastMachineItemHandler;
+import com.rexbas.teletubbies.inventory.container.slot.SpecificItemSlot;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -58,7 +59,7 @@ public class ToastMachineBlockEntity extends BlockEntity implements MenuProvider
 
 		if (!level.isClientSide) {
 			if (this.isPowered()) {
-				if (handler.getStackInSlot(0).getItem().equals(Items.WHEAT)) {
+				if (handler.getStackInSlot(0).is(SpecificItemSlot.GRAIN)) {
 					this.tickCounter++;
 					
 					if (tickCounter >= TICKS_PER_BAR) {

--- a/src/main/java/com/rexbas/teletubbies/inventory/container/CustardMachineContainer.java
+++ b/src/main/java/com/rexbas/teletubbies/inventory/container/CustardMachineContainer.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 
 import com.rexbas.teletubbies.block.entity.CustardMachineBlockEntity;
 import com.rexbas.teletubbies.init.TeletubbiesContainers;
-import com.rexbas.teletubbies.init.TeletubbiesItems;
 import com.rexbas.teletubbies.inventory.container.handler.CustardMachineItemHandler;
 import com.rexbas.teletubbies.inventory.container.slot.CustardMachineOutputSlot;
 import com.rexbas.teletubbies.inventory.container.slot.SpecificItemSlot;
@@ -16,7 +15,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -47,12 +45,12 @@ public class CustardMachineContainer extends AbstractContainerMenu {
 	
 	private void addMachineSlots(CustardMachineItemHandler inputHandler, CustardMachineItemHandler outputHandler) {
 		for (int i = 0; i < 4; ++i) {
-			this.addSlot(new SpecificItemSlot(inputHandler, i, 8, 16 + i * 18, Items.MILK_BUCKET));
+			this.addSlot(new SpecificItemSlot(inputHandler, i, 8, 16 + i * 18, SpecificItemSlot.MILK));
 			this.addSlot(new CustardMachineOutputSlot(outputHandler, i, 152, 16 + i * 18));
 		}
-		this.addSlot(new SpecificItemSlot(inputHandler, 4, 32, 25, Items.SUGAR));
-		this.addSlot(new SpecificItemSlot(inputHandler, 5, 32, 43, Items.EGG));
-		this.addSlot(new SpecificItemSlot(inputHandler, 6, 32, 61, TeletubbiesItems.BOWL.get()));
+		this.addSlot(new SpecificItemSlot(inputHandler, 4, 32, 25, SpecificItemSlot.SUGAR));
+		this.addSlot(new SpecificItemSlot(inputHandler, 5, 32, 43, SpecificItemSlot.EGG));
+		this.addSlot(new SpecificItemSlot(inputHandler, 6, 32, 61, SpecificItemSlot.BOWL));
 		this.addSlot(new CustardMachineOutputSlot(outputHandler, 4, 128, 43));
 	}
 	

--- a/src/main/java/com/rexbas/teletubbies/inventory/container/ToastMachineContainer.java
+++ b/src/main/java/com/rexbas/teletubbies/inventory/container/ToastMachineContainer.java
@@ -13,7 +13,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -42,7 +41,7 @@ public class ToastMachineContainer extends AbstractContainerMenu {
 	}
 	
 	private void addMachineSlots(ToastMachineItemHandler handler) {
-		this.addSlot(new SpecificItemSlot(handler, 0, 61, 37, Items.WHEAT));
+		this.addSlot(new SpecificItemSlot(handler, 0, 61, 37, SpecificItemSlot.GRAIN));
 	}
 	
 	private void addPlayerSlots() {

--- a/src/main/java/com/rexbas/teletubbies/inventory/container/handler/CustardMachineItemHandler.java
+++ b/src/main/java/com/rexbas/teletubbies/inventory/container/handler/CustardMachineItemHandler.java
@@ -3,6 +3,7 @@ package com.rexbas.teletubbies.inventory.container.handler;
 import javax.annotation.Nonnull;
 
 import com.rexbas.teletubbies.init.TeletubbiesItems;
+import com.rexbas.teletubbies.inventory.container.slot.SpecificItemSlot;
 
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -22,13 +23,13 @@ public class CustardMachineItemHandler extends ItemStackHandler {
 	        case 1:
 	        case 2:
 	        case 3:
-	            return stack.getItem().equals(Items.MILK_BUCKET);
+	            return stack.is(SpecificItemSlot.MILK);
 	        case 4:
-	            return stack.getItem().equals(Items.SUGAR);
+	            return stack.is(SpecificItemSlot.SUGAR);
 	        case 5:
-	            return stack.getItem().equals(Items.EGG);
+	            return stack.is(SpecificItemSlot.EGG);
 	        case 6:
-	            return stack.getItem().equals(TeletubbiesItems.BOWL.get());
+	            return stack.is(SpecificItemSlot.BOWL);
 	        }
     	}
     	else if (this.stacks.size() == 5) {
@@ -37,9 +38,9 @@ public class CustardMachineItemHandler extends ItemStackHandler {
 	        case 1:
 	        case 2:
 	        case 3:
-	            return stack.getItem().equals(TeletubbiesItems.CUSTARD.get());
+	            return stack.is(TeletubbiesItems.CUSTARD.get());
 	        case 4:
-	            return stack.getItem().equals(Items.BUCKET);
+	            return stack.is(Items.BUCKET);
 	        }
     	}
     		

--- a/src/main/java/com/rexbas/teletubbies/inventory/container/handler/ToastMachineItemHandler.java
+++ b/src/main/java/com/rexbas/teletubbies/inventory/container/handler/ToastMachineItemHandler.java
@@ -2,8 +2,8 @@ package com.rexbas.teletubbies.inventory.container.handler;
 
 import javax.annotation.Nonnull;
 
+import com.rexbas.teletubbies.inventory.container.slot.SpecificItemSlot;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraftforge.items.ItemStackHandler;
 
 public class ToastMachineItemHandler extends ItemStackHandler {
@@ -14,6 +14,6 @@ public class ToastMachineItemHandler extends ItemStackHandler {
 	
     @Override
     public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-        return stack.getItem().equals(Items.WHEAT);
+        return stack.is(SpecificItemSlot.GRAIN);
     }
 }

--- a/src/main/java/com/rexbas/teletubbies/inventory/container/slot/SpecificItemSlot.java
+++ b/src/main/java/com/rexbas/teletubbies/inventory/container/slot/SpecificItemSlot.java
@@ -2,6 +2,9 @@ package com.rexbas.teletubbies.inventory.container.slot;
 
 import javax.annotation.Nonnull;
 
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
@@ -9,15 +12,21 @@ import net.minecraftforge.items.SlotItemHandler;
 
 public class SpecificItemSlot extends SlotItemHandler {
 
-	private final Item item;
+	public static final TagKey<Item> GRAIN = ItemTags.create(new ResourceLocation("forge", "grain"));
+	public static final TagKey<Item> MILK = ItemTags.create(new ResourceLocation("forge", "milk"));
+	public static final TagKey<Item> EGG = ItemTags.create(new ResourceLocation("forge", "egg"));
+	public static final TagKey<Item> SUGAR = ItemTags.create(new ResourceLocation("forge", "sugar"));
+	public static final TagKey<Item> BOWL = ItemTags.create(new ResourceLocation("teletubbies", "bowl"));
+
+	private final TagKey<Item> item;
 	
-	public SpecificItemSlot(IItemHandler itemHandler, int index, int xPosition, int yPosition, Item item) {
+	public SpecificItemSlot(IItemHandler itemHandler, int index, int xPosition, int yPosition, TagKey<Item> item) {
 		super(itemHandler, index, xPosition, yPosition);
 		this.item = item;
 	}
 	
     @Override
 	public boolean mayPlace(@Nonnull ItemStack stack) {
-    	return stack.getItem().equals(item);
+    	return stack.is(item);
     }
 }

--- a/src/main/resources/data/forge/tags/items/egg.json
+++ b/src/main/resources/data/forge/tags/items/egg.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:egg/egg"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/egg/egg.json
+++ b/src/main/resources/data/forge/tags/items/egg/egg.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:egg"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/grain.json
+++ b/src/main/resources/data/forge/tags/items/grain.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:grain/wheat"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/grain/wheat.json
+++ b/src/main/resources/data/forge/tags/items/grain/wheat.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:wheat"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/milk.json
+++ b/src/main/resources/data/forge/tags/items/milk.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:milk/milk"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/milk/milk.json
+++ b/src/main/resources/data/forge/tags/items/milk/milk.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:milk_bucket"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/rods.json
+++ b/src/main/resources/data/forge/tags/items/rods.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:rods/teletubbies"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/rods/teletubbies.json
+++ b/src/main/resources/data/forge/tags/items/rods/teletubbies.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "teletubbies:tinkywinky_stick",
+    "teletubbies:dipsy_stick",
+    "teletubbies:laalaa_stick",
+    "teletubbies:po_stick"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/sugar.json
+++ b/src/main/resources/data/forge/tags/items/sugar.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:sugar/sugar"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/sugar/sugar.json
+++ b/src/main/resources/data/forge/tags/items/sugar/sugar.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:sugar"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/toast.json
+++ b/src/main/resources/data/forge/tags/items/toast.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:toast/tubby_toast"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/toast/tubby_toast.json
+++ b/src/main/resources/data/forge/tags/items/toast/tubby_toast.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "teletubbies:toast"
+  ]
+}

--- a/src/main/resources/data/teletubbies/recipes/control_panel.json
+++ b/src/main/resources/data/teletubbies/recipes/control_panel.json
@@ -9,20 +9,9 @@
     "H": {
       "item": "minecraft:hopper"
     },
-    "S": [
-      {
-        "item": "teletubbies:tinkywinky_stick"
-      },
-      {
-        "item": "teletubbies:dipsy_stick"
-      },
-      {
-        "item": "teletubbies:laalaa_stick"
-      },
-      {
-        "item": "teletubbies:po_stick"
-      }
-    ]
+    "S": {
+      "tag": "forge:rods/teletubbies"
+    }
   },
   "result": {
     "item": "teletubbies:control_panel"

--- a/src/main/resources/data/teletubbies/recipes/custard_machine.json
+++ b/src/main/resources/data/teletubbies/recipes/custard_machine.json
@@ -12,20 +12,9 @@
     "C": {
       "item": "minecraft:magenta_concrete"
     },
-    "S": [
-      {
-        "item": "teletubbies:tinkywinky_stick"
-      },
-      {
-        "item": "teletubbies:dipsy_stick"
-      },
-      {
-        "item": "teletubbies:laalaa_stick"
-      },
-      {
-        "item": "teletubbies:po_stick"
-      }
-    ]
+    "S": {
+      "tag": "forge:rods/teletubbies"
+    }
   },
   "result": {
     "item": "teletubbies:custard_machine"

--- a/src/main/resources/data/teletubbies/recipes/toast_machine.json
+++ b/src/main/resources/data/teletubbies/recipes/toast_machine.json
@@ -15,20 +15,9 @@
     "L": {
       "item": "minecraft:lapis_block"
     },
-    "S": [
-      {
-        "item": "teletubbies:tinkywinky_stick"
-      },
-      {
-        "item": "teletubbies:dipsy_stick"
-      },
-      {
-        "item": "teletubbies:laalaa_stick"
-      },
-      {
-        "item": "teletubbies:po_stick"
-      }
-    ]
+    "S": {
+      "tag": "forge:rods/teletubbies"
+    }
   },
   "result": {
     "item": "teletubbies:toast_machine"

--- a/src/main/resources/data/teletubbies/tags/items/bowl.json
+++ b/src/main/resources/data/teletubbies/tags/items/bowl.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "teletubbies:bowl"
+  ]
+}


### PR DESCRIPTION
I did this for my 1.15 modpack, but I also did it for 1.19 so it will work out of the box as soon as Pam's Harvestcraft gets updated to the newest version of Minecraft. Unless you prefer to keep your code the way it is, of course.

This patch makes the `SpecificItemSlot` accept items based on their tag, enabling wheat and milk bucket substitutes from Pam's Harvestcraft to work. The Tubby Custard Machine remembers whether you inserted a milk bucket or a modded milk item, so it only gives the bucket back if needed.

I also gave Tubby Toast the `forge:toast/tubby_toast` tag, and the sticks/antennae the `forge:rods/teletubbies` tag (I would name these "Antenna" instead of "Stick" but that's up to you 🙂), so they work in modded recipes that accept all toasts or rods.

Screenshots from 1.15:
![2022-12-23_19 04 46](https://user-images.githubusercontent.com/2750434/209392128-a3ca5a86-9a2a-4e89-910b-f7712f127f80.png)
![2022-12-23_19 04 26](https://user-images.githubusercontent.com/2750434/209392141-2d5e5283-0a39-4238-a915-2f267cf1ea09.png)
![2022-12-23_19 06 43](https://user-images.githubusercontent.com/2750434/209392146-d2a374d1-a2b0-4405-9a57-d3e10a8f44ef.png)
